### PR TITLE
fix dhparam when undef

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@ class prosody (
   $ssl_protocol           = 'tlsv1',
   $ssl_options            = ['no_ticket', 'no_compression', 'cipher_server_preference'],
   $ssl_ciphers            = 'DH+AES:ECDH+AES:+ECDH+SHA:AES:!PSK:!SRP:!DSS:!ADH:!AECDH',
-  $ssl_dhparam            = undef,
+  $ssl_dhparam            = '',
   $ssl_curve              = 'secp521r1',
   $c2s_require_encryption = true,
   $s2s_require_encryption = true,

--- a/templates/prosody.cfg.erb
+++ b/templates/prosody.cfg.erb
@@ -100,7 +100,7 @@ ssl = {
   ciphers = "<%= scope.lookupvar('prosody::ssl_ciphers') %>";
   curve = "<%= scope.lookupvar('prosody::ssl_curve') %>";
   <%- dhparam = scope.lookupvar('prosody::ssl_dhparam')
-      if dhparam != :undef -%>
+      if dhparam != '' -%>
   dhparam = "<%= dhparam %>";
   <% end -%>
 }


### PR DESCRIPTION
tested on puppet 3.8 and puppet 4.8.2.
Without this patch it add an empty dh_parameter to the config on puppet 4 !